### PR TITLE
Add & improve type annotations for Camera overhaul

### DIFF
--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -249,7 +249,7 @@ class Camera2D:
         return self._projection.right - self._projection.left
 
     @projection_width.setter
-    def projection_width(self, _width: float):
+    def projection_width(self, _width: float) -> None:
         w = self.projection_width
         l = self.projection_left / w  # Normalised Projection left
         r = self.projection_right / w  # Normalised Projection Right
@@ -607,7 +607,7 @@ class Camera2D:
         return degrees(atan2(self._data.position[0], self._data.position[1]))
 
     @angle.setter
-    def angle(self, value: float):
+    def angle(self, value: float) -> None:
         """
         Set the 2D UP vector using an angle.
         This starts with 0 degrees as [0, 1]

--- a/arcade/camera/controllers/simple_controller_classes.py
+++ b/arcade/camera/controllers/simple_controller_classes.py
@@ -97,7 +97,7 @@ class ScreenShakeController:
         return self._acceleration_duration + self.falloff_duration
 
     @duration.setter
-    def duration(self, _duration: float):
+    def duration(self, _duration: float) -> None:
         if _duration <= 0.0:
             self.falloff_duration = -1.0
 
@@ -125,7 +125,7 @@ class ScreenShakeController:
         return self._acceleration_duration
 
     @acceleration_duration.setter
-    def acceleration_duration(self, _duration):
+    def acceleration_duration(self, _duration: float) -> None:
         if _duration < 0.0:
             self._acceleration_duration = 0.0
         else:
@@ -143,7 +143,7 @@ class ScreenShakeController:
         return 1 / self._acceleration_duration
 
     @acceleration.setter
-    def acceleration(self, _acceleration: float):
+    def acceleration(self, _acceleration: float) -> None:
         if _acceleration <= 0.0:
             self._acceleration_duration = 0.0
         else:
@@ -162,7 +162,7 @@ class ScreenShakeController:
         return (15 / 8) * (1 / self.falloff_duration)
 
     @falloff.setter
-    def falloff(self, _falloff: float):
+    def falloff(self, _falloff: float) -> None:
         if _falloff <= 0.0:
             self.falloff_duration = -1.0
         else:
@@ -188,7 +188,7 @@ class ScreenShakeController:
         """
         return 1 - _t**3 * (_t * (_t * 6.0 - 15.0) + 10.0)
 
-    def _calc_max_amp(self):
+    def _calc_max_amp(self) -> float:
         """
         Determine the maximum amplitude by using either _acceleration_amp() or _falloff_amp().
         If falloff duration is less than 0.0 then the falloff never begins and
@@ -206,13 +206,13 @@ class ScreenShakeController:
 
         return 0.0
 
-    def _calc_amplitude(self):
+    def _calc_amplitude(self) -> float:
         _max_amp = self._calc_max_amp()
         _sin_amp = sin(self.shake_frequency * 2.0 * pi * self._length_shaking)
 
         return _sin_amp * _max_amp
 
-    def reset(self):
+    def reset(self) -> None:
         """
         Reset the temporary shaking variables. WILL NOT STOP OR START SCREEN SHAKE.
         """
@@ -221,14 +221,14 @@ class ScreenShakeController:
         self._last_update_time = 0.0
         self._length_shaking = 0.0
 
-    def start(self):
+    def start(self) -> None:
         """
         Start the screen-shake.
         """
         self.reset()
         self._shaking = True
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Instantly stop the screen-shake.
         """
@@ -241,7 +241,7 @@ class ScreenShakeController:
         self.reset()
         self._shaking = False
 
-    def update(self, delta_time: float):
+    def update(self, delta_time: float) -> None:
         """
         Update the time, and decide if the shaking should stop.
         Does not actually set the camera position.
@@ -260,7 +260,7 @@ class ScreenShakeController:
         if self.falloff_duration > 0.0 and self._length_shaking >= self.duration:
             self.stop()
 
-    def update_camera(self):
+    def update_camera(self) -> None:
         """
         Update the position of the camera. Call this just before using the camera.
         because the controller is modifying the PoD directly it stores the last
@@ -293,7 +293,7 @@ class ScreenShakeController:
         )
         self._last_update_time = self._length_shaking
 
-    def readjust_camera(self):
+    def readjust_camera(self) -> None:
         """
         Can be called after the camera has been used revert the screen_shake.
         While not strictly necessary it is highly advisable. If you are moving the

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -31,28 +31,29 @@ class ViewportProjector:
             window: The window to bind the camera to. Defaults to the currently active window.
         """
         self._window = window or get_window()
-
         self._viewport = viewport or self._window.ctx.viewport
-        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(0.0, self._viewport[2],
-                                                                   0.0, self._viewport[3],
-                                                                   -100, 100)
+        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
+            0.0, self._viewport[2],
+            0.0, self._viewport[3],
+            -100, 100
+        )
 
     @property
-    def viewport(self):
+    def viewport(self) -> Tuple[int, int, int, int]:
         """
         The viewport use to derive projection and view matrix.
         """
         return self._viewport
 
     @viewport.setter
-    def viewport(self, viewport: Tuple[int, int, int, int]):
+    def viewport(self, viewport: Tuple[int, int, int, int]) -> None:
         self._viewport = viewport
+        self._projection_matrix = Mat4.orthogonal_projection(
+            0, viewport[2],
+            0, viewport[3],
+            -100, 100)
 
-        self._projection_matrix = Mat4.orthogonal_projection(0, viewport[2],
-                                                             0, viewport[3],
-                                                             -100, 100)
-
-    def use(self):
+    def use(self) -> None:
         """
         Set the window's projection and view matrix.
         Also sets the projector as the windows current camera.
@@ -106,7 +107,7 @@ class DefaultProjector(ViewportProjector):
         """
         super().__init__(window=window)
 
-    def use(self):
+    def use(self) -> None:
         """
         Set the window's Projection and View matrices.
 

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -125,7 +125,7 @@ class OrthographicProjector:
             -ri.dot(po), -up.dot(po), fo.dot(po), 1
         ))
 
-    def use(self):
+    def use(self) -> None:
         """
         Sets the active camera to this object.
         Then generates the view and projection matrices.

--- a/arcade/camera/simple_camera.py
+++ b/arcade/camera/simple_camera.py
@@ -317,7 +317,7 @@ class SimpleCamera:
             if self.position == self._position_goal:
                 self._easing_speed = 0.0
 
-    def use(self):
+    def use(self) -> None:
         """
         Sets the active camera to this object.
         Then generates the view and projection matrices.

--- a/arcade/camera/types.py
+++ b/arcade/camera/types.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
 from typing import Protocol, Tuple, Iterator
 from contextlib import contextmanager
 
 
 __all__ = [
     'Projection',
-    'Projector'
+    'Projector',
+    'Camera'
 ]
 
 
@@ -20,8 +22,17 @@ class Projector(Protocol):
         ...
 
     @contextmanager
-    def activate(self) -> Iterator["Projector"]:
+    def activate(self) -> Iterator[Projector]:
         ...
 
     def map_coordinate(self, screen_coordinate: Tuple[float, float], depth: float = 0.0) -> Tuple[float, ...]:
+        ...
+
+
+class Camera(Protocol):
+
+    def use(self) -> None:
+        ...
+
+    def activate(self) -> Iterator[Projector]:
         ...


### PR DESCRIPTION
* Add missing annotations in simple_controller_classes.py

* Add missing return annotation to OrthographicProjector.use()

* Add missing return annotation to SimpleCamerea.use()

* Add Camera Protocol type to arcade.camera.types

* Correct overly-wide lines in ViewportProjector.__init__

* Add missing return annotation to ViewportProjector.viewport property

* Fix return annotation + overwide lines in ViewportProjector.viewport setter

* Add return type annotation to ViewportProjector.use()

* Add return annotation to DefaultProjector.use()

* Add return annotation to Camera2D.projection_width setter

* Add return annotation to Camera2D.angle setter

* Add Camera protocol to __all__ in arcade.camera.types

* Use recursive definition in Projector Protocol