### PR TITLE
Depth-of-field style improvements

### DIFF
--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -5,20 +5,18 @@ python -m arcade.experimental.examples.array_backed_grid
 """
 from typing import Tuple, Optional
 from textwrap import dedent
-from contextlib import contextmanager
 from math import cos, pi
 from random import uniform, randint
+from contextlib import contextmanager
 
 from pyglet.graphics import Batch
 
+from arcade import get_window, Window, SpriteSolidColor, SpriteList, Text
 from arcade.color import RED
 from arcade.types import Color, RGBA255
 
-from arcade import Window, SpriteSolidColor, SpriteList, Text
-
 from arcade.gl import geometry, NEAREST, Program, Texture2D
 from arcade.experimental.postprocessing import GaussianBlur
-from arcade import get_window, draw_text
 
 
 class DepthOfField:
@@ -207,6 +205,6 @@ class App(Window):
         self.dof.render()
         self._batch.draw()
 
+
 if __name__ == '__main__':
     App().run()
-

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -13,7 +13,7 @@ from arcade.types import Color, RGBA255
 
 from arcade import Window, SpriteSolidColor, SpriteList
 
-from arcade.gl import geometry, NEAREST
+from arcade.gl import geometry, NEAREST, Program
 from arcade.experimental.postprocessing import GaussianBlur
 from arcade import get_window, draw_text
 
@@ -109,6 +109,10 @@ class DepthOfField:
         self._render_program['texture_1'] = 1
         self._render_program['depth_0'] = 2
 
+    @property
+    def render_program(self) -> Program:
+        return self._render_program
+
     @contextmanager
     def draw_into(self):
         self.stale = True
@@ -159,7 +163,7 @@ class App(Window):
 
     def on_update(self, delta_time: float):
         self.time += delta_time
-        self.dof._render_program["focus_depth"] = round(
+        self.dof.render_program["focus_depth"] = round(
             16 * (cos(pi * 0.1 * self.time) * 0.5 + 0.5)) / 16
 
     def on_draw(self):
@@ -169,7 +173,7 @@ class App(Window):
         self.use()
 
         self.dof.render()
-        draw_text(str(self.dof._render_program["focus_depth"]), self.width / 2, self.height / 2, (255, 0, 0, 255),
+        draw_text(str(self.dof.render_program["focus_depth"]), self.width / 2, self.height / 2, (255, 0, 0, 255),
                   align="center")
 
 

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -1,3 +1,8 @@
+"""An experimental depth-of-field example.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.experimental.examples.array_backed_grid
+"""
 from typing import Tuple, Optional
 from contextlib import contextmanager
 from math import cos, pi

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -38,6 +38,7 @@ class DepthOfField:
     :param size: The size of the buffers.
     :param clear_color: The color which will be used as the background.
     """
+
     def __init__(
             self,
             size: Optional[Tuple[int, int]] = None,
@@ -181,7 +182,7 @@ class App(Window):
         self._batch = Batch()
         self.focus_range = focus_range
         self.indicator_label = Text(
-            f"Focus depth: {0}",
+            f"Focus depth: {0:.3f} / {focus_range}",
             self.width / 2, self.height / 2,
             text_color,
             align="center",

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -1,5 +1,18 @@
 """An experimental depth-of-field example.
 
+It uses the depth attribute of along with blurring and shaders to
+roughly approximate depth-based blur effects.
+
+For each frame, it does the following:
+
+1. Render a depth value for pixel into a buffer
+2. Render a gaussian blurred version of the scene
+3. For each pixel, use the current depth value to lerp between the
+   blurred and unblurred versions of the scene.
+
+This is more expensive than rendering the scene directly, but it's
+both easier and more performant than more accurate blur approaches.
+
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.experimental.examples.array_backed_grid
 """

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -8,6 +8,9 @@ from textwrap import dedent
 from contextlib import contextmanager
 from math import cos, pi
 from random import uniform, randint
+
+from arcade.types import Color
+
 from arcade import Window, SpriteSolidColor, SpriteList
 
 from arcade.gl import geometry, NEAREST
@@ -136,15 +139,15 @@ class App(Window):
         self.t = 0.0
         self.l: SpriteList = SpriteList()
         for _ in range(100):
-            d = uniform(-100, 100)
-            c = int(255 * (d + 100) / 200)
+            depth = uniform(-100, 100)
+            color = Color.from_gray(int(255 * (depth + 100) / 200))
             s = SpriteSolidColor(
                 randint(100, 200), randint(100, 200),
                 uniform(20, self.width - 20), uniform(20, self.height - 20),
-                (c, c, c, 255),
+                color,
                 uniform(0, 360)
             )
-            s.depth = d
+            s.depth = depth
             self.l.append(s)
         self.dof = DepthOfField()
 

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -20,7 +20,11 @@ from arcade.experimental.postprocessing import GaussianBlur
 
 
 class DepthOfField:
+    """A depth-of-field effect we can use as a render context manager.
 
+    :param size: The size of the buffers.
+    :param clear_color: The color which will be used as the background.
+    """
     def __init__(
             self,
             size: Optional[Tuple[int, int]] = None,

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -4,6 +4,7 @@ If Python and Arcade are installed, this example can be run from the command lin
 python -m arcade.experimental.examples.array_backed_grid
 """
 from typing import Tuple, Optional
+from textwrap import dedent
 from contextlib import contextmanager
 from math import cos, pi
 from random import uniform, randint
@@ -61,41 +62,39 @@ class DepthOfField:
         )
 
         self._render_program = self._win.ctx.program(
-            vertex_shader=(
-                "#version 330\n"
-                "\n"
-                "in vec2 in_vert;\n"
-                "in vec2 in_uv;\n"
-                "\n"
-                "out vec2 out_uv;\n"
-                "\n"
-                "void main(){\n"
-                "   gl_Position = vec4(in_vert, 0.0, 1.0);\n"
-                "   out_uv = in_uv;\n"
-                "}\n"
-            ),
-            fragment_shader=(
-                "#version 330\n"
-                "\n"
-                "uniform sampler2D texture_0;\n"
-                "uniform sampler2D texture_1;\n"
-                "uniform sampler2D depth_0;\n"
-                "\n"
-                "uniform float focus_depth;\n"
-                "\n"
-                "in vec2 out_uv;\n"
-                "\n"
-                "out vec4 frag_colour;\n"
-                "\n"
-                "void main() {\n"
-                "   float depth_val = texture(depth_0, out_uv).x;\n"
-                "   float depth_adjusted = min(1.0, 2.0 * abs(depth_val - focus_depth));\n"
-                "   vec4 crisp_tex = texture(texture_0, out_uv);\n"
-                "   vec3 blur_tex = texture(texture_1, out_uv).rgb;\n"
-                "   frag_colour = mix(crisp_tex, vec4(blur_tex, crisp_tex.a), depth_adjusted);\n"
-                "   //if (depth_adjusted < 0.1){frag_colour = vec4(1.0, 0.0, 0.0, 1.0);}\n"
-                "}\n"
-            )
+            vertex_shader=dedent(
+                """#version 330
+
+                in vec2 in_vert;
+                in vec2 in_uv;
+
+                out vec2 out_uv;
+
+                void main(){
+                   gl_Position = vec4(in_vert, 0.0, 1.0);
+                   out_uv = in_uv;
+                }"""),
+            fragment_shader=dedent(
+                """#version 330
+
+                uniform sampler2D texture_0;
+                uniform sampler2D texture_1;
+                uniform sampler2D depth_0;
+
+                uniform float focus_depth;
+
+                in vec2 out_uv;
+
+                out vec4 frag_colour;
+
+                void main() {
+                   float depth_val = texture(depth_0, out_uv).x;
+                   float depth_adjusted = min(1.0, 2.0 * abs(depth_val - focus_depth));
+                   vec4 crisp_tex = texture(texture_0, out_uv);
+                   vec3 blur_tex = texture(texture_1, out_uv).rgb;
+                   frag_colour = mix(crisp_tex, vec4(blur_tex, crisp_tex.a), depth_adjusted);
+                   //if (depth_adjusted < 0.1){frag_colour = vec4(1.0, 0.0, 0.0, 1.0);}
+                }""")
         )
         self._render_program['texture_0'] = 0
         self._render_program['texture_1'] = 1

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -1,9 +1,12 @@
 """An experimental depth-of-field example.
 
 It uses the depth attribute of along with blurring and shaders to
-roughly approximate depth-based blur effects.
+roughly approximate depth-based blur effects. The focus bounces
+back forth automatically between a maximum and minimum depth value
+based on time. Adjust the arguments to the App class at the bottom
+of the file to change the speed.
 
-For each frame, it does the following:
+This example works by doing the following for each frame:
 
 1. Render a depth value for pixel into a buffer
 2. Render a gaussian blurred version of the scene
@@ -170,17 +173,25 @@ class DepthOfField:
 
 
 class App(Window):
+    """Window subclass to hold sprites and rendering helpers.
 
+    :param text_color: The color of the focus indicator.
+    :param focus_range: The range the focus value will oscillate between.
+    :param focus_change_speed: How fast the focus bounces back and forth
+        between the ``-focus_range`` and ``focus_range``.
+    """
     def __init__(
             self,
             text_color: RGBA255 = RED,
-            focus_range: float = 16.0
+            focus_range: float = 16.0,
+            focus_change_speed: float = 0.1
     ):
         super().__init__()
         self.time: float = 0.0
         self.sprites: SpriteList = SpriteList()
         self._batch = Batch()
-        self.focus_range = focus_range
+        self.focus_range: float = focus_range
+        self.focus_change_speed: float = focus_change_speed
         self.indicator_label = Text(
             f"Focus depth: {0:.3f} / {focus_range}",
             self.width / 2, self.height / 2,
@@ -207,7 +218,7 @@ class App(Window):
 
     def on_update(self, delta_time: float):
         self.time += delta_time
-        raw_focus = self.focus_range * (cos(pi * 0.1 * self.time) * 0.5 + 0.5)
+        raw_focus = self.focus_range * (cos(pi * self.focus_change_speed * self.time) * 0.5 + 0.5)
         self.dof.render_program["focus_depth"] = raw_focus / self.focus_range
         self.indicator_label.value = f"Focus depth: {raw_focus:.3f} / {self.focus_range}"
 

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -19,7 +19,7 @@ both easier and more performant than more accurate blur approaches.
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.experimental.examples.array_backed_grid
 """
-from typing import Tuple, Optional
+from typing import Tuple, Optional, cast
 from textwrap import dedent
 from math import cos, pi
 from random import uniform, randint
@@ -50,7 +50,7 @@ class DepthOfField:
         self._geo = geometry.quad_2d_fs()
         self._win: Window = get_window()
 
-        size: Tuple[int, int] = size or self._win.size
+        size = cast(Tuple[int, int], size or self._win.size)
         self._clear_color: Color = Color.from_iterable(clear_color)
 
         self.stale = True

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -24,7 +24,7 @@ class DepthOfField:
     def __init__(
             self,
             size: Optional[Tuple[int, int]] = None,
-            clear_color: RGBA255 = Color(155, 155, 155, 255)
+            clear_color: RGBA255 = (155, 155, 155, 255)
     ):
         self._geo = geometry.quad_2d_fs()
         self._win: Window = get_window()


### PR DESCRIPTION
### Changes

* Add top-level docstring with explanation and run instructions
* Clean up the shader source using [`textwrap.dedent`](https://docs.python.org/3/library/textwrap.html)
* Replace single-letter variable names with more readable ones
* Improve clarity with comments, docstrings, and type annotations
* Use keyword versions of arguments to create the `GaussianBlur` effect
* Turn some hardcoded values into keyword argments with defaults

### Steps taken

- [x] `ruff check arcade/experimental/depth_of_field`
- [x] `mypy arcade/experimental/depth_of_field`