### PR TITLE
Touchup touchups

### DIFF
--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -190,12 +190,81 @@ class Projection(Protocol):
 
 
 class Projector(Protocol):
+    """Projects from world coordinates to viewport pixel coordinates.
+
+    Projectors also support converting in the opposite direction from
+    screen pixel coordinates to world space coordinates.
+
+    The two key spatial methods which do this are:
+
+    .. list-table::
+       :header-rows: 1
+       * - Method
+         - Action
+
+       * - :py:meth:`.project`
+         - Turn world coordinates into pixel coordinates relative
+           to the origin (bottom left by default).
+
+       * - :py:meth:`.unproject`
+         - Convert screen pixel coordinates into world space.
+
+    .. note: Every :py:class:`.Camera` is also a kind of projector.
+
+    The other required methods are for helping manage which camera is
+    currently used to draw.
+
+    """
 
     def use(self) -> None:
+        """Set the GL context to use this projector and its settings.
+
+        .. warning:: You may be looking for:py:meth:`.activate`!
+
+                     This method only sets rendering state for a given
+                     projector. Since it doesn't restore any afterward,
+                     it's easy to misuse in ways which can cause bugs
+                     or temporarily break a game's rendering until
+                     relaunch. For reliable, automatic clean-up see
+                     the :py:meth:`.activate` method instead.
+
+        If you are implementing your own custom projector, this method
+        should only:
+
+        #. Set the Arcade :py:class:`~arcade.Window`'s
+           :py:attr:`~arcade.Window.current_camera` to this object
+        #. Calculate any required view and projection matrices
+        #. Set any resulting values on the current
+           :py:class:`~arcade.context.ArcadeContext`, including the:
+
+           * :py:attr:`~arcade.context.ArcadeContext.viewport`
+           * :py:attr:`~arcade.context.ArcadeContext.view_matrix`
+           * :py:attr:`~arcade.context.ArcadeContext.projection_matrix`
+
+        This method should **never** handle cleanup. That is the
+        responsibility of :py:attr:`.activate`.
+
+        """
         ...
 
     @contextmanager
     def activate(self) -> Iterator[Projector]:
+        """Set this camera as the current one, then undo it after.
+
+        This method is a :ref+external:`context manager <context-managers>`
+        you can use inside ``with`` blocks. Using it this way guarantees
+        that the old camera and its settings will be restored, even if an
+        exception occurs:
+
+        .. code-block:: python
+
+           # Despite an Exception, the previous camera and its settings
+           # will be restored at the end of the with block below:
+           with projector_instance.activate():
+                sprite_list.draw()
+                _ = 1 / 0  # Guaranteed ZeroDivisionError
+
+        """
         ...
 
     def map_screen_to_world_coordinate(

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -184,6 +184,45 @@ class PerspectiveProjectionData:
 
 
 class Projection(Protocol):
+    """Matches the data universal in Arcade's projection data objects.
+
+    There are multiple types of projections used in games, but all the
+    common ones share key features. This :py:class:`~typing.Protocol`:
+
+    #. Defines those shared elements
+    #. Annotates these in code for both humans and automated type
+       checkers
+
+    The specific implementations which match it are used inside of
+    implementations of Arcade's :py:class:`.Projector` behavior. All
+    of these projectors rely on a ``viewport`` as well as ``near`` and
+    ``far`` values.
+
+    The ``viewport`` is measured in screen pixels. By default, the
+    conventions for this are the same as the rest of Arcade and
+    OpenGL:
+
+    * X is measured rightward from left of the screen
+    * Y is measured up from the bottom of the screen
+
+    Although the ``near`` and ``far`` values are describe the cutoffs
+    for what the camera sees in world space, the exact meaning differs
+    between projection type.
+
+    .. list-table::
+       :header-rows: 1
+
+       * - Common Projection Type
+         - Meaning of ``near`` & ``far``
+
+       * - Simple Orthographic
+         - The Z position in world space
+
+       * - Perspective & Isometric
+         - Where the rear and front clipping planes sit along a
+           camera's :py:attr:`.CameraData.forward` vector.
+
+    """
     viewport: Tuple[int, int, int, int]
     near: float
     far: float

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,5 +1,4 @@
-from typing import Optional, Tuple, Iterator, TYPE_CHECKING
-from contextlib import contextmanager
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from pyglet.math import Mat4, Vec4
 
@@ -16,7 +15,7 @@ __all__ = [
 ]
 
 
-class OrthographicProjector:
+class OrthographicProjector(Projector):
     """
     The simplest from of an orthographic camera.
     Using ViewData and OrthographicProjectionData PoDs (Pack of Data)
@@ -102,19 +101,6 @@ class OrthographicProjector:
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
         self._window.view = _view
-
-    @contextmanager
-    def activate(self) -> Iterator[Projector]:
-        """
-        A context manager version of OrthographicProjector.use() which allows for the use of
-        `with` blocks. For example, `with camera.activate() as cam: ...`.
-        """
-        previous_projector = self._window.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous_projector.use()
 
     def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = ("PerspectiveProjector",)
 
 
-class PerspectiveProjector:
+class PerspectiveProjector(Projector):
     """
     The simplest from of a perspective camera.
     Using ViewData and PerspectiveProjectionData PoDs (Pack of Data)
@@ -101,20 +101,6 @@ class PerspectiveProjector:
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
         self._window.view = _view
-
-
-    @contextmanager
-    def activate(self) -> Iterator[Projector]:
-        """
-        A context manager version of OrthographicProjector.use() which allows for the use of
-        `with` blocks. For example, `with camera.activate() as cam: ...`.
-        """
-        previous_projector = self._window.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous_projector.use()
 
     def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """


### PR DESCRIPTION
1. Docstrings for a bunch of data types
2. Move default implementation of `activate` on `Projector` protocol
3. Inherit where possible from `Projector` protocol
